### PR TITLE
fix: hide forced password prompt input

### DIFF
--- a/internal/cli/password.go
+++ b/internal/cli/password.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"errors"
+	"fmt"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgconn"
+	"golang.org/x/term"
 )
 
 // shouldAskForPassword decides whether to prompt for password based on error code and flags.
@@ -16,4 +19,16 @@ func shouldAskForPassword(err error, neverPrompt bool) bool {
 		return true
 	}
 	return false
+}
+
+var readPassword = term.ReadPassword
+
+func promptPassword() (string, error) {
+	fmt.Print("Password: ")
+	password, err := readPassword(int(os.Stdin.Fd()))
+	fmt.Println()
+	if err != nil {
+		return "", err
+	}
+	return string(password), nil
 }

--- a/internal/cli/password_test.go
+++ b/internal/cli/password_test.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -45,4 +48,31 @@ func Test_shouldAskForPassword(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_promptPassword(t *testing.T) {
+	originalReadPassword := readPassword
+	originalStdout := os.Stdout
+	t.Cleanup(func() {
+		readPassword = originalReadPassword
+		os.Stdout = originalStdout
+	})
+
+	readPassword = func(fd int) ([]byte, error) {
+		return []byte("secret"), nil
+	}
+
+	reader, writer, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stdout = writer
+
+	password, err := promptPassword()
+	assert.NoError(t, err)
+	assert.Equal(t, "secret", password)
+
+	assert.NoError(t, writer.Close())
+	var output bytes.Buffer
+	_, err = io.Copy(&output, reader)
+	assert.NoError(t, err)
+	assert.Equal(t, "Password: \n", output.String())
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -393,16 +393,6 @@ func parsePositionalDBAndUser(args []string) (string, string) {
 	return db, user
 }
 
-func promptPassword() (string, error) {
-	var pwd string
-	fmt.Print("Password: ")
-	_, err := fmt.Scanln(&pwd)
-	if err != nil {
-		return "", err
-	}
-	return pwd, nil
-}
-
 func mustParsePort(port string) (uint16, error) {
 	portNum, err := strconv.Atoi(port)
 	if err != nil {


### PR DESCRIPTION
## Summary

- replace the forced password prompt's `fmt.Scanln` input with `term.ReadPassword`
- keep the existing `Password:` prompt while moving password input off the echoing terminal path
- add a regression test around the prompt wrapper

Fixes #48.

## Tests

- `PATH=/Users/ming/.cache/go-toolchains/go1.26.2/bin:$PATH go test ./internal/cli`
- `PATH=/Users/ming/.cache/go-toolchains/go1.26.2/bin:$PATH go test ./...`
- `PATH=/Users/ming/.cache/go-toolchains/go1.26.2/bin:$PATH go vet ./...`

Note: the system `go` is 1.19.5, so I used a local Go 1.26.2 toolchain to satisfy this repo's `go 1.25.8` directive. `make lint` could not run locally because this machine's CommandLineTools `xcrun` is the wrong architecture; the Go test/vet checks above passed.
