### PR TITLE
fix: added history file pruning if over maxHistoryLimit

### DIFF
--- a/internal/app/history.go
+++ b/internal/app/history.go
@@ -86,14 +86,23 @@ func (h *history) saveHistory(entries []prompt.HistoryCommand) error {
 		return nil
 	}
 
-	newCommands := entries[h.loadCount:]
-
 	historyDir := filepath.Dir(h.path)
 	if err := os.MkdirAll(historyDir, 0o700); err != nil {
 		return err
 	}
 
-	f, err := os.OpenFile(h.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	var commands []prompt.HistoryCommand
+	flags := os.O_CREATE | os.O_WRONLY
+
+	if len(entries) > maxHistoryLines {
+		commands = entries[max(0, len(entries)-maxHistoryLines):]
+		flags |= os.O_TRUNC
+	} else {
+		commands = entries[h.loadCount:]
+		flags |= os.O_APPEND
+	}
+
+	f, err := os.OpenFile(h.path, flags, 0o600)
 	if err != nil {
 		return err
 	}
@@ -104,7 +113,7 @@ func (h *history) saveHistory(entries []prompt.HistoryCommand) error {
 	}()
 
 	w := bufio.NewWriter(f)
-	for _, entry := range newCommands {
+	for _, entry := range commands {
 		line, err := json.Marshal(entry)
 		if err != nil {
 			h.logger.Warn("skipping entry, failed to marshal", "command", entry.Command, "error", err)
@@ -122,7 +131,7 @@ func (h *history) saveHistory(entries []prompt.HistoryCommand) error {
 	if err := w.Flush(); err != nil {
 		return err
 	}
-	h.logger.Debug("history saved", "new_entries", len(newCommands))
+	h.logger.Debug("history saved", "entries_written", len(commands))
 	return nil
 }
 

--- a/internal/app/history_test.go
+++ b/internal/app/history_test.go
@@ -153,9 +153,13 @@ func TestHistorySaveHistory_PrunesWhenOverLimit(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
 	assert.Len(t, lines, maxHistoryLines)
 
-	var mostRecentCommand prompt.HistoryCommand
-	assert.NoError(t, json.Unmarshal([]byte(lines[maxHistoryLines-1]), &mostRecentCommand))
-	assert.Equal(t, entries[len(entries)-1], mostRecentCommand)
+	var firstCommand prompt.HistoryCommand
+	assert.NoError(t, json.Unmarshal([]byte(lines[0]), &firstCommand))
+	assert.Equal(t, entries[len(entries)-maxHistoryLines], firstCommand)
+
+	var lastCommand prompt.HistoryCommand
+	assert.NoError(t, json.Unmarshal([]byte(lines[maxHistoryLines-1]), &lastCommand))
+	assert.Equal(t, entries[len(entries)-1], lastCommand)
 }
 
 func TestLoadHistory(t *testing.T) {

--- a/internal/app/history_test.go
+++ b/internal/app/history_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -126,6 +127,35 @@ func TestHistorySaveHistory_FailsOnInvalidPath(t *testing.T) {
 	err := h.saveHistory(entries)
 
 	assert.Error(t, err)
+}
+
+func TestHistorySaveHistory_PrunesWhenOverLimit(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "history_test_prune")
+	assert.NoError(t, err)
+	defer func() {
+		closeErr := tempFile.Close()
+		assert.NoError(t, closeErr)
+		err := os.Remove(tempFile.Name())
+		assert.NoError(t, err)
+	}()
+
+	h := history{path: tempFile.Name(), loadCount: maxHistoryLines, logger: testLogger()}
+	entries := make([]prompt.HistoryCommand, maxHistoryLines+10)
+	for i := range entries {
+		entries[i] = prompt.HistoryCommand{Command: fmt.Sprintf("select %d", i)}
+	}
+
+	err = h.saveHistory(entries)
+	assert.NoError(t, err)
+
+	data, err := os.ReadFile(tempFile.Name())
+	assert.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	assert.Len(t, lines, maxHistoryLines)
+
+	var mostRecentCommand prompt.HistoryCommand
+	assert.NoError(t, json.Unmarshal([]byte(lines[maxHistoryLines-1]), &mostRecentCommand))
+	assert.Equal(t, entries[len(entries)-1], mostRecentCommand)
 }
 
 func TestLoadHistory(t *testing.T) {


### PR DESCRIPTION
Cool project! Hope this helps :)  

- Updated `saveHistory` to respect the `maxHistoryLines` limit
  - When `len(entries) > maxHistoryLines`, the history file is rewritten with `O_TRUNC`, keeping only the last `maxHistoryLimit` entries                                                           
  - When under the limit, appends only new commands with `O_APPEND`, this is the original behavior.     
  - Renamed `newCommands` to `commands` and updated the debug log key from `new_entries` to `entries_written`. Please feel free to push back as this simply made more sense in my head, but would prefer your input!
  - Added `TestHistorySaveHistory_PrunesWhenOverLimit` to verify the file is truncated to exactly `maxHistoryLines` entries. Specifically, that the tail and head entries are preserved                                                                                                                                                         
                                                                                                                                                                        
fixes #50                                                                                                                                                             
