### PR TITLE
fix: show error message on invalid password retry

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -304,6 +304,7 @@ func connectWithFields(
 	}
 
 	cliCtx.Logger.Debug("Connection failed, prompting for password")
+	fmt.Println("Wrong password, try again")
 	pwd, err := promptPassword()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Adds a visible error message when password authentication fails while using the `-W` flag.

## Changes

* Display "Wrong password, try again" before re-prompting for password.

## Testing

* Ran `go test ./...`
* Verified retry flow manually using an invalid password.

Closes #63
