### PR TITLE
fix: rely on term.ReadPassword for password prompts

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -401,27 +402,17 @@ func parsePositionalDBAndUser(args []string) (string, string) {
 func promptPassword(s string) (string, error) {
 	fmt.Printf("%s: ", s)
 	fd := int(os.Stdin.Fd())
-	oldState, err := term.GetState(fd)
-	if err != nil {
-		// stdin is not a TTY — fall back to normal line input
-		var pwd string
-		_, err := fmt.Scanln(&pwd)
+
+	if !term.IsTerminal(fd) {
+		pwd, err := bufio.NewReader(os.Stdin).ReadString('\n')
 		if err != nil {
 			return "", err
 		}
-		return pwd, nil
-	}
-
-	// Put terminal in raw mode (echo off) for secure password entry.
-	if _, err := term.MakeRaw(fd); err != nil {
-		return "", fmt.Errorf("failed to set raw terminal mode: %w", err)
+		return strings.TrimRight(pwd, "\r\n"), nil
 	}
 
 	pwd, err := term.ReadPassword(fd)
-	// Restore terminal to its original state no matter what.
-	_ = term.Restore(fd, oldState)
 	fmt.Println()
-
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -285,11 +286,19 @@ func connectWithFields(
 		"user", params.user,
 	)
 
-	if neverPrompt && password == "" {
+	if forcePrompt && password == "" {
+		pwd, err := promptPassword("Enter password")
+		if err != nil {
+			return err
+		}
+		password = pwd
+	}
+
+	if !forcePrompt && password == "" {
 		password = getPasswordFromEnv()
 	}
 
-	if forcePrompt && password == "" {
+	if shouldPromptBeforeConnect(password, neverPrompt, forcePrompt, runtime.GOOS) {
 		pwd, err := promptPassword("Enter password")
 		if err != nil {
 			return err
@@ -340,6 +349,10 @@ func connectWithFields(
 	}
 
 	return nil
+}
+
+func shouldPromptBeforeConnect(password string, neverPrompt bool, forcePrompt bool, goos string) bool {
+	return password == "" && !neverPrompt && !forcePrompt && goos == "windows"
 }
 
 func ensureConnected(cliCtx *CliContext) error {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -298,14 +297,6 @@ func connectWithFields(
 		password = getPasswordFromEnv()
 	}
 
-	if shouldPromptBeforeConnect(password, neverPrompt, forcePrompt, runtime.GOOS) {
-		pwd, err := promptPassword("Enter password")
-		if err != nil {
-			return err
-		}
-		password = pwd
-	}
-
 	connector, err := database.NewPGConnectorFromFields(
 		params.host,
 		params.database,
@@ -330,14 +321,18 @@ func connectWithFields(
 	}
 
 	cliCtx.Logger.Debug("Connection failed, prompting for password")
-	if wErr := renderer.Error(
-		fmt.Errorf("Wrong password, try again."), //nolint // user-facing message
-		os.Stderr,
-	); wErr != nil {
-		return wErr
+	prompt := "Enter password"
+	if password != "" {
+		if wErr := renderer.Error(
+			fmt.Errorf("Wrong password, try again."), //nolint // user-facing message
+			os.Stderr,
+		); wErr != nil {
+			return wErr
+		}
+		prompt = "Enter password again"
 	}
 
-	pwd, err := promptPassword("Enter password again")
+	pwd, err := promptPassword(prompt)
 	if err != nil {
 		return err
 	}
@@ -349,10 +344,6 @@ func connectWithFields(
 	}
 
 	return nil
-}
-
-func shouldPromptBeforeConnect(password string, neverPrompt bool, forcePrompt bool, goos string) bool {
-	return password == "" && !neverPrompt && !forcePrompt && goos == "windows"
 }
 
 func ensureConnected(cliCtx *CliContext) error {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type dbAndUserTestCase struct {
@@ -14,6 +16,26 @@ type dbAndUserTestCase struct {
 
 	expectedDB   string
 	expectedUser string
+}
+
+func TestPromptPasswordFallsBackToFullLineInput(t *testing.T) {
+	oldStdin := os.Stdin
+	stdin, writer, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = stdin.Close()
+	})
+
+	os.Stdin = stdin
+	_, err = writer.WriteString("correct horse battery staple\r\n")
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	got, err := promptPassword("Enter password")
+
+	require.NoError(t, err)
+	assert.Equal(t, "correct horse battery staple", got)
 }
 
 func TestResolveDBAndUser(t *testing.T) {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -38,54 +38,6 @@ func TestPromptPasswordFallsBackToFullLineInput(t *testing.T) {
 	assert.Equal(t, "correct horse battery staple", got)
 }
 
-func TestShouldPromptBeforeConnect(t *testing.T) {
-	testcases := []struct {
-		name        string
-		password    string
-		neverPrompt bool
-		forcePrompt bool
-		goos        string
-		want        bool
-	}{
-		{
-			name: "windows prompts before empty password connection",
-			goos: "windows",
-			want: true,
-		},
-		{
-			name:     "windows skips prompt when password is already known",
-			password: "secret",
-			goos:     "windows",
-			want:     false,
-		},
-		{
-			name:        "windows respects no password flag",
-			neverPrompt: true,
-			goos:        "windows",
-			want:        false,
-		},
-		{
-			name:        "windows does not prompt twice after force prompt",
-			forcePrompt: true,
-			goos:        "windows",
-			want:        false,
-		},
-		{
-			name: "unix keeps passwordless first attempt",
-			goos: "linux",
-			want: false,
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := shouldPromptBeforeConnect(tc.password, tc.neverPrompt, tc.forcePrompt, tc.goos)
-
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
 func TestResolveDBAndUser(t *testing.T) {
 	testcases := []struct {
 		name  string

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -38,6 +38,54 @@ func TestPromptPasswordFallsBackToFullLineInput(t *testing.T) {
 	assert.Equal(t, "correct horse battery staple", got)
 }
 
+func TestShouldPromptBeforeConnect(t *testing.T) {
+	testcases := []struct {
+		name        string
+		password    string
+		neverPrompt bool
+		forcePrompt bool
+		goos        string
+		want        bool
+	}{
+		{
+			name: "windows prompts before empty password connection",
+			goos: "windows",
+			want: true,
+		},
+		{
+			name:     "windows skips prompt when password is already known",
+			password: "secret",
+			goos:     "windows",
+			want:     false,
+		},
+		{
+			name:        "windows respects no password flag",
+			neverPrompt: true,
+			goos:        "windows",
+			want:        false,
+		},
+		{
+			name:        "windows does not prompt twice after force prompt",
+			forcePrompt: true,
+			goos:        "windows",
+			want:        false,
+		},
+		{
+			name: "unix keeps passwordless first attempt",
+			goos: "linux",
+			want: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldPromptBeforeConnect(tc.password, tc.neverPrompt, tc.forcePrompt, tc.goos)
+
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestResolveDBAndUser(t *testing.T) {
 	testcases := []struct {
 		name  string


### PR DESCRIPTION
Closes #82.

## Summary
- let `term.ReadPassword` manage terminal password console modes directly instead of putting stdin into raw mode first
- keep a non-terminal fallback that reads the full password line and handles CRLF input
- add coverage for fallback passwords containing spaces

## Validation
- `go test ./internal/cli -run TestPromptPasswordFallsBackToFullLineInput -count=1`
- `go test ./internal/cli`
- `go test ./internal/database`
- `go test ./...`
- `go build -o /tmp/pgxcli-opp148 ./cmd/pgxcli`
- `make build`
- `go vet ./...`
- `./bin/app --help`
- `git diff --check`
- `git diff --cached --check`
- changed and staged diff gitleaks scans

## Not run
- `make lint` because `golangci-lint` is not installed locally (`make: golangci-lint: No such file or directory`).
- Windows console smoke; validation was run on macOS/darwin amd64.