### PR TITLE
feat: double ESC to clear the input

### DIFF
--- a/internal/app/ui/keys.go
+++ b/internal/app/ui/keys.go
@@ -6,6 +6,7 @@ import "charm.land/bubbles/v2/key"
 type KeyMap struct {
 	Quit      key.Binding
 	Interrupt key.Binding
+	Clear     key.Binding
 }
 
 // DefaultKeyMap returns the default keybindings.
@@ -18,6 +19,10 @@ func DefaultKeyMap() KeyMap {
 		Interrupt: key.NewBinding(
 			key.WithKeys("ctrl+c"),
 			key.WithHelp("ctrl+c", "interrupt"),
+		),
+		Clear: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc esc", "clear"),
 		),
 	}
 }

--- a/internal/app/ui/model.go
+++ b/internal/app/ui/model.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
@@ -27,6 +28,7 @@ type State int
 const (
 	StateInput State = iota
 	StateExecuting
+	StatePending
 )
 
 // ReadyMsg signals the ui that execution is done and it should prompt.
@@ -40,6 +42,10 @@ type QuitRequestMsg struct{}
 
 // ConfirmQuitMsg is used internally to finalize quitting.
 type ConfirmQuitMsg struct{}
+
+// seqTimeoutMsg is sent after 500ms to cancel a pending key
+// seq if the second key was not pressed on time.
+type seqTimeoutMsg struct{ seq int }
 
 type cancel func(ctx context.Context) error
 
@@ -56,6 +62,7 @@ type Model struct {
 	prevUserInput string
 	version       string
 	highlighter   func(string) string
+	escSeq        int
 
 	keys   KeyMap
 	styles Styles
@@ -168,6 +175,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m.handleInput()
 
+	case seqTimeoutMsg:
+		if msg.seq == m.escSeq {
+			m.state = StateInput
+		}
+		return m, nil
+
 	case tea.KeyMsg:
 		if key.Matches(msg, m.keys.Quit) {
 			return m, func() tea.Msg {
@@ -188,6 +201,22 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			m.input.Reset()
 			return m, nil
+		}
+		if key.Matches(msg, m.keys.Clear) {
+			if m.state == StateExecuting {
+				return m, nil
+			}
+			if m.state == StatePending {
+				m.state = StateInput
+				m.input.Reset()
+				return m, nil
+			}
+			m.state = StatePending
+			m.escSeq++
+			n := m.escSeq
+			return m, tea.Tick(500*time.Millisecond, func(t time.Time) tea.Msg {
+				return seqTimeoutMsg{seq: n}
+			})
 		}
 	}
 

--- a/internal/app/ui/model.go
+++ b/internal/app/ui/model.go
@@ -182,6 +182,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		if m.state == StatePending && !key.Matches(msg, m.keys.Clear) {
+			m.state = StateInput
+		}
+
 		if key.Matches(msg, m.keys.Quit) {
 			return m, func() tea.Msg {
 				return QuitRequestMsg{}

--- a/pgxspecial/dbcommands/util_test.go
+++ b/pgxspecial/dbcommands/util_test.go
@@ -330,7 +330,6 @@ func RequiresRowResult(t *testing.T, r pgxspecial.SpecialCommandResult) pgxspeci
 		t.Fatalf("expected rows result, got %T", r)
 	}
 
-
 	rowsResult, ok := r.(pgxspecial.RowResult)
 	if !ok {
 		t.Fatalf("expected RowsResult, got %T", r)

--- a/pgxspecial/export.go
+++ b/pgxspecial/export.go
@@ -6,7 +6,7 @@ func Export() []CommandExport {
 	for key, cmd := range commandRegistry {
 		// key contains the command name with the alias
 		// \quit, '\q, \exit has the same command, only differs by key/alias
-		cmd := New(key, cmd.Syntax, cmd.Description) 
+		cmd := New(key, cmd.Syntax, cmd.Description)
 		cmds = append(cmds, cmd)
 	}
 	return cmds

--- a/pgxspecial/registry_test.go
+++ b/pgxspecial/registry_test.go
@@ -162,7 +162,6 @@ func TestExecuteCommand(t *testing.T) {
 		t.Errorf("Expected result kind to be rows, got: %T", result)
 	}
 
-
 	rows := result.(pgxspecial.RowResult).Rows
 
 	defer rows.Close()
@@ -201,7 +200,6 @@ func TestRegisterCommandAlias(t *testing.T) {
 	if !isRow {
 		t.Errorf("Expected result kind to be rows, got: %T", result)
 	}
-
 
 	rows := result.(pgxspecial.RowResult).Rows
 	defer rows.Close()


### PR DESCRIPTION
Closes #73

## Changes

### `internal/app/ui/keys.go`
- Added `Clear key.Binding` to `KeyMap` struct
- Added `esc` keybinding in `DefaultKeyMap()` with help text `esc esc, clear input`

### `internal/app/ui/model.go`
- Added `StatePending` to the const
- Added `seqTimeoutMsg` struct to carry the sequence number when the 500ms timer is triggered
- Added `escSeq int` field to `Model` to track the current **esc** seq generation
- Added `time` to imports
- In `Update()`: added `Clear` key handler inside `tea.KeyMsg` block:
  - first **esc** sets `StatePending` and fires a `tea.Tick`
  - second **esc** within 500ms calls `m.input.Reset()` and returns to `StateInput`
- In `Update()`: added `escTimeoutMsg` case, 
  - cancels pending state if the sequence number matches
 
 
> Note: the 3 other files changes is maybe due to fmt, because it just removed 3 empty lines and 1 space, should i revert it or keep it?