### PR TITLE
Respect XDG_CONFIG_HOME for config path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ For full flag documentation, see the [docs][cli-ref].
 
 On first run, a config file is created at:
 
-* `~/.config/pgxcli/config.toml` (or the OS-equivalent user config directory)
+* `$XDG_CONFIG_HOME/pgxcli/config.toml` (or the OS-equivalent user config directory)
 
-For configuration documentation, see the [docs][config-ref]
+For configuration documentation, see the [configuration docs][config-ref].
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- CONTRIBUTING -->
@@ -187,7 +187,7 @@ Thank you for being part of the community! 🙌
 [pgcli-url]: https://github.com/dbcli/pgcli
 [sqls-url]: https://github.com/sqls-server/sqls
 [cockroachdb-url]: https://github.com/cockroachdb/cockroach
-[cli-ref]: https://pgxcli.vercel.app/reference/cli-reference/
-[config-ref]: https://pgxcli.vercel.app/guides/configuration/
+[cli-ref]: https://pgxcli.vercel.app/docs/reference/cli-reference/
+[config-ref]: https://pgxcli.vercel.app/docs/guides/configuration
 [install-ref]: https://pgxcli.vercel.app/docs/guides/getting-started#installation
 [releases-url]: https://github.com/balajz/pgxcli/releases

--- a/docs/docs/guides/configuration.md
+++ b/docs/docs/guides/configuration.md
@@ -8,7 +8,7 @@ sidebar_position: 4
 On first run, pgxcli creates a config file at:
 
 ```
-~/.config/pgxcli/config.toml
+$XDG_CONFIG_HOME/pgxcli/config.toml
 ```
 
 (Or the OS-equivalent user config directory.)

--- a/docs/docs/guides/getting-started.mdx
+++ b/docs/docs/guides/getting-started.mdx
@@ -116,7 +116,7 @@ pgxcli mydb myuser
 That's it. You'll get a REPL with syntax highlighting, autocompletion, and history — ready to go.
 
 :::tip
-On first run, pgxcli creates a config file at `~/.config/pgxcli/config.toml`. You can customize your prompt, theme, pager, and more. See [Configuration](/docs/guides/configuration).
+On first run, pgxcli creates a config file at `$XDG_CONFIG_HOME/pgxcli/config.toml` when `XDG_CONFIG_HOME` is set, otherwise in the OS-standard user config directory. You can customize your prompt, theme, pager, and more. See [Configuration](/docs/guides/configuration).
 :::
 
 ### Try a Query

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,10 @@ func GetDefaultConfig() (*Config, error) {
 
 // UserConfigPath returns the user config path (for example: ~/.config/pgxcli/config.toml).
 func UserConfigPath() (string, error) {
+	if userdir := os.Getenv("XDG_CONFIG_HOME"); userdir != "" {
+		return filepath.Join(userdir, appName, filename), nil
+	}
+
 	userdir, err := os.UserConfigDir()
 	if err != nil {
 		return "", err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,6 +110,15 @@ func TestUserConfigPath(t *testing.T) {
 	assert.Contains(t, path, appName)
 }
 
+func TestUserConfigPath_UsesXDGConfigHomeWhenSet(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+
+	path, err := UserConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tempDir, appName, filename), path)
+}
+
 func TestEnsureUserConfig_CreatesConfigOnFirstRun(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "config.toml")


### PR DESCRIPTION
Respect XDG_CONFIG_HOME for config path resolution.

On mac os the `os.UserConfigDir()` resolved to `$HOME/Library/Application Support` which nobody use:)