### PR TITLE
fix(cli): honor PGPORT when --port is omitted

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -180,9 +180,7 @@ func resolveConnectionParams(
 		hostOpt = getHostFromEnv()
 	}
 
-	if portOpt == 0 {
-		portOpt = getPortFromEnv()
-	}
+	portOpt = resolvePort(cmd, portOpt)
 
 	return connectionParams{
 		database: database,
@@ -211,8 +209,8 @@ func resolveInteractiveConnectionParams(
 	if cmd.Flags().Changed("host") {
 		formHost = hostOpt
 	}
-	if cmd.Flags().Changed("port") {
-		formPort = strconv.FormatUint(uint64(portOpt), 10)
+	if cmd.Flags().Changed("port") || getPortFromEnv() != 0 {
+		formPort = strconv.FormatUint(uint64(resolvePort(cmd, portOpt)), 10)
 	}
 
 	connValues, err := ui.RunConnectionForm(formDB, formUser, formHost, formPort)
@@ -235,6 +233,20 @@ func resolveInteractiveConnectionParams(
 	}
 
 	return params, nil
+}
+
+// resolvePort applies connection-port precedence while preserving Cobra's displayed default.
+// An explicitly supplied --port (including --port=5432) wins over environment defaults.
+func resolvePort(cmd *cobra.Command, portOpt uint16) uint16 {
+	if cmd.Flags().Changed("port") {
+		return portOpt
+	}
+
+	if portFromEnv := getPortFromEnv(); portFromEnv != 0 {
+		return portFromEnv
+	}
+
+	return portOpt
 }
 
 func connectClient(

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -127,6 +128,44 @@ func TestResolveDBAndUser(t *testing.T) {
 			actualDB, actualUser := resolveDBAndUser(tc.input.dbnameOpt, tc.input.userOpt, tc.input.argDB, tc.input.argUser)
 			assert.Equal(t, tc.input.expectedDB, actualDB, "finalDB does not match expected value")
 			assert.Equal(t, tc.input.expectedUser, actualUser, "finalUser does not match expected value")
+		})
+	}
+}
+
+func TestResolvePort(t *testing.T) {
+	newCmd := func(t *testing.T) *cobra.Command {
+		t.Helper()
+		cmd := &cobra.Command{}
+		cmd.Flags().Uint16("port", 5432, "port number")
+		return cmd
+	}
+
+	tests := []struct {
+		name     string
+		pgxPort  string
+		pgPort   string
+		explicit string
+		expected uint16
+	}{
+		{name: "uses PGXPORT when flag is omitted", pgxPort: "6543", expected: 6543},
+		{name: "uses PGPORT when PGXPORT is absent", pgPort: "6544", expected: 6544},
+		{name: "PGXPORT takes precedence over PGPORT", pgxPort: "6543", pgPort: "6544", expected: 6543},
+		{name: "explicit port takes precedence over environment", pgPort: "6544", explicit: "5432", expected: 5432},
+		{name: "keeps the flag default when no environment port is set", expected: 5432},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PGXPORT", tt.pgxPort)
+			t.Setenv("PGPORT", tt.pgPort)
+			cmd := newCmd(t)
+			if tt.explicit != "" {
+				require.NoError(t, cmd.Flags().Set("port", tt.explicit))
+			}
+
+			port, err := cmd.Flags().GetUint16("port")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, resolvePort(cmd, port))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- honor `PGXPORT` / `PGPORT` when `--port` is omitted
- preserve explicit `--port` precedence, including `--port=5432`
- prefill the interactive port field from the environment when available

## Tests
- `GOPROXY=direct /tmp/go/bin/go test ./internal/cli`
- `GOPROXY=direct /tmp/go/bin/go test ./...`