### PR TITLE
fix(cli): keep exit farewell out of non-interactive output

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -78,7 +78,12 @@ func NewRootCmd(ctx context.Context, cliCtx *CliContext) *cobra.Command {
 				cliCtx.Logger.Error("Application context not initialized")
 				return fmt.Errorf("application context not initialized")
 			}
-			return cliCtx.App.Start(ctx)
+			if err := cliCtx.App.Start(ctx); err != nil {
+				return err
+			}
+			cliCtx.Printer.Println("Thanks for using Pgxcli.")
+			cliCtx.Printer.Println("see you next time.")
+			return nil
 		},
 
 		PersistentPostRunE: func(_ *cobra.Command, _ []string) error {

--- a/main.go
+++ b/main.go
@@ -29,7 +29,4 @@ func main() {
 		printer.PrintError(err)
 		os.Exit(1)
 	}
-
-	printer.Println("Thanks for using Pgxcli.")
-	printer.Println("see you next time.")
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG (program behavior)
- [ ] Typo
- [ ] Improvement
- [ ] Feature

## What does this PR do?

`main.go` printed `Thanks for using Pgxcli.` and `see you next time.` after every successful Cobra command. This appended human-facing lines to non-interactive output such as `--help` and `--version`, making the output harder for scripts to consume.

The farewell is now emitted only after the interactive application returns successfully from `internal/cli/root.go`. Non-interactive commands remain clean, while normal REPL exits retain the existing message.

## Validation

- `go test ./...`
- `go build -o /tmp/pgxcli-farewell-final .`
- Built binary `--help`: no farewell lines
- Built binary `--version`: `pgxcli version 0.3.0`, no farewell lines
- `git diff --check`
