### PR TITLE
refactor(app): isolate local command dispatch

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,10 +29,6 @@ type Application interface {
 	Close() error
 }
 
-var builtinsCommand = map[string]func() tea.Cmd{
-	"\\clear": func() tea.Cmd { return tea.ClearScreen },
-}
-
 // pgxCLI is the main implementation of the Application interface.
 type pgxCLI struct {
 	model      *ui.Model
@@ -63,9 +59,9 @@ func New(cfg *config.Config, printer cliio.Printer, logger *slog.Logger, client 
 func (p *pgxCLI) execute(ctx context.Context, query string) tea.Cmd {
 	p.logger.Debug("received command", "command_length", len(query))
 
-	if cmd, ok := builtinsCommand[query]; ok {
+	if cmd, ok := p.runLocal(query); ok {
 		p.logger.Debug("executing builtin command", "command", query)
-		return p.withPrompt(cmd())
+		return p.withPrompt(cmd)
 	}
 
 	return func() tea.Msg {

--- a/internal/app/local_commands.go
+++ b/internal/app/local_commands.go
@@ -1,0 +1,18 @@
+package app
+
+import tea "charm.land/bubbletea/v2"
+
+type localCommand func(*pgxCLI) tea.Cmd
+
+var localCommands = map[string]localCommand{
+	"\\clear": func(_ *pgxCLI) tea.Cmd { return tea.ClearScreen },
+}
+
+func (p *pgxCLI) runLocal(query string) (tea.Cmd, bool) {
+	command, ok := localCommands[query]
+	if !ok {
+		return nil, false
+	}
+
+	return command(p), true
+}

--- a/internal/app/local_commands_test.go
+++ b/internal/app/local_commands_test.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunLocalMatchesClearExactly(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		query string
+		match bool
+	}{
+		{name: "backslash clear", query: `\clear`, match: true},
+		{name: "forward slash clear", query: `/clear`, match: false},
+		{name: "uppercase", query: `\CLEAR`, match: false},
+		{name: "leading whitespace", query: ` \clear`, match: false},
+		{name: "trailing whitespace", query: `\clear `, match: false},
+		{name: "argument", query: `\clear now`, match: false},
+		{name: "empty", query: "", match: false},
+	}
+
+	cli := &pgxCLI{}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd, matched := cli.runLocal(testCase.query)
+			assert.Equal(t, testCase.match, matched)
+			if testCase.match {
+				require.NotNil(t, cmd)
+				assert.Equal(t, tea.ClearScreen(), cmd())
+				return
+			}
+			assert.Nil(t, cmd)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This separates client-side command dispatch from the main execution path.

Previously, `app.go` contained both the local command registry and its lookup logic. This change moves those responsibilities into `local_commands.go`, leaving `execute` focused on deciding whether an input should be handled locally or passed to the existing meta-command and SQL execution paths.

The existing `\clear` command is used to establish this boundary. Its handler, logging, prompt handling, and exact-match behavior remain unchanged.

## Changes

- move the local command registry out of `app.go`
- introduce `runLocal` as the local command lookup and dispatch entry point
- keep prompt wrapping and logging in the existing execution flow
- add regression tests for `\clear` dispatch and exact command matching

## Behavior

This is a structural refactor with no intended user-facing changes.

## Testing

- `go test ./...`
- `go vet ./...`
- `golangci-lint run`