### PR TITLE
fix(cli): print farewell after successful cleanup

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -85,20 +86,28 @@ func NewRootCmd(ctx context.Context, cliCtx *CliContext) *cobra.Command {
 		},
 
 		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
-			if cliCtx.App != nil {
-				if err := cliCtx.App.Close(); err != nil {
-					return err
-				}
-			}
-			if cliCtx.Client != nil {
-				if err := cliCtx.Client.Close(ctx); err != nil {
-					return err
-				}
-			}
-			if cliCtx.Logger != nil {
-				if err := cliCtx.Logger.Close(); err != nil {
-					return err
-				}
+			cleanupErr := closeResources(
+				func() error {
+					if cliCtx.App == nil {
+						return nil
+					}
+					return cliCtx.App.Close()
+				},
+				func() error {
+					if cliCtx.Client == nil {
+						return nil
+					}
+					return cliCtx.Client.Close(ctx)
+				},
+				func() error {
+					if cliCtx.Logger == nil {
+						return nil
+					}
+					return cliCtx.Logger.Close()
+				},
+			)
+			if cleanupErr != nil {
+				return cleanupErr
 			}
 			// Keep future non-interactive subcommand output free of the interactive farewell.
 			if cmd == cmd.Root() {
@@ -126,6 +135,19 @@ func NewRootCmd(ctx context.Context, cliCtx *CliContext) *cobra.Command {
 	rootCmd.MarkFlagsMutuallyExclusive("no-password", "password")
 
 	return rootCmd
+}
+
+// Close every resource so failures do not prevent later cleanup.
+func closeResources(closers ...func() error) error {
+	var errs []error
+
+	for _, close := range closers {
+		if err := close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 type connectionParams struct {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -81,12 +81,10 @@ func NewRootCmd(ctx context.Context, cliCtx *CliContext) *cobra.Command {
 			if err := cliCtx.App.Start(ctx); err != nil {
 				return err
 			}
-			cliCtx.Printer.Println("Thanks for using Pgxcli.")
-			cliCtx.Printer.Println("see you next time.")
 			return nil
 		},
 
-		PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
+		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
 			if cliCtx.App != nil {
 				if err := cliCtx.App.Close(); err != nil {
 					return err
@@ -101,6 +99,11 @@ func NewRootCmd(ctx context.Context, cliCtx *CliContext) *cobra.Command {
 				if err := cliCtx.Logger.Close(); err != nil {
 					return err
 				}
+			}
+			// Keep future non-interactive subcommand output free of the interactive farewell.
+			if cmd == cmd.Root() {
+				cliCtx.Printer.Println("Thanks for using Pgxcli.")
+				cliCtx.Printer.Println("see you next time.")
 			}
 			return nil
 		},

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,9 +1,15 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/balajz/pgxcli/internal/cliio"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +23,91 @@ type dbAndUserTestCase struct {
 
 	expectedDB   string
 	expectedUser string
+}
+
+type testApp struct {
+	closeErr    error
+	closeCalled bool
+}
+
+func (a *testApp) Start(context.Context) error { return nil }
+
+func (a *testApp) Close() error {
+	a.closeCalled = true
+	return a.closeErr
+}
+
+func TestCloseResourcesClosesEverythingAndJoinsErrors(t *testing.T) {
+	t.Parallel()
+
+	appErr := errors.New("app close failed")
+	loggerErr := errors.New("logger close failed")
+	var calls []string
+
+	err := closeResources(
+		func() error {
+			calls = append(calls, "app")
+			return appErr
+		},
+		func() error {
+			calls = append(calls, "client")
+			return nil
+		},
+		func() error {
+			calls = append(calls, "logger")
+			return loggerErr
+		},
+	)
+
+	assert.Equal(t, []string{"app", "client", "logger"}, calls)
+	assert.ErrorIs(t, err, appErr)
+	assert.ErrorIs(t, err, loggerErr)
+}
+
+func TestPersistentPostRunCleanupAndFarewell(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		childCommand bool
+		cleanupFails bool
+		wantFarewell bool
+	}{
+		{name: "root success", wantFarewell: true},
+		{name: "root failure", cleanupFails: true},
+		{name: "child success", childCommand: true},
+		{name: "child failure", childCommand: true, cleanupFails: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var output bytes.Buffer
+			var closeErr error
+			if testCase.cleanupFails {
+				closeErr = errors.New("history save failed")
+			}
+			testApplication := &testApp{closeErr: closeErr}
+			cliCtx := &CliContext{
+				App:     testApplication,
+				Printer: cliio.NewPgxPrinter(&output, io.Discard),
+			}
+			rootCmd := NewRootCmd(context.Background(), cliCtx)
+			cmd := rootCmd
+			if testCase.childCommand {
+				cmd = &cobra.Command{Use: "export"}
+				rootCmd.AddCommand(cmd)
+			}
+
+			err := rootCmd.PersistentPostRunE(cmd, nil)
+			if closeErr != nil {
+				require.ErrorIs(t, err, closeErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.True(t, testApplication.closeCalled)
+			assert.Equal(t, testCase.wantFarewell, strings.Contains(output.String(), "Thanks for using Pgxcli."))
+		})
+	}
 }
 
 func TestPromptPasswordFallsBackToFullLineInput(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

This is a follow-up to [#110](https://github.com/balajz/pgxcli/pull/110) and addresses the cleanup ordering noted in [this review comment](https://github.com/balajz/pgxcli/pull/110#issuecomment-5303283286).

PR #110 correctly removed the farewell from `--help` and `--version`, but moved it into `RunE`, before `PersistentPostRunE` closes the application, database client, and logger. If cleanup fails, the farewell is printed before the command returns an error.

This change moves the farewell to the end of `PersistentPostRunE`, so it is printed only after cleanup succeeds.

Because persistent hooks can also run for child commands, the farewell is limited to the root command. This keeps future non-interactive commands, such as `pgxcli export`, from including the interactive farewell in their output.

## Reproduction

Using the default history path:

```sh
touch ~/.pgxcli_history.jsonl
chmod a-w ~/.pgxcli_history.jsonl
go run . <connection arguments>
```

Exit pgxcli with `\q`.

On the current `main`, the farewell is printed before the history-save error. With this change, only the error is printed.

Remember to restore the file permissions:

```sh
chmod u+w ~/.pgxcli_history.jsonl
```
